### PR TITLE
Repair resource data corrupted by the daily-2026-08-08 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A structured and human-curated collection of OCR and Document AI resources. Auto
 | --- | ---: | --- |
 | [Papers](papers/README.md) | 244 | Research on OCR, document parsing, layout analysis, and document understanding |
 | [Models](models/README.md) | 110 | Public model cards, weights, APIs, and official model releases |
-| [Datasets](datasets/README.md) | 51 | Training datasets and evaluation benchmarks |
+| [Datasets](datasets/README.md) | 52 | Training datasets and evaluation benchmarks |
 | [Codes](codes/README.md) | 35 | Notable OCR and Document AI codebases |
 | [Skills](skills/README.md) | 104 | Installable agent skills for OCR and document workflows |
 | [Platforms](platforms/README.md) | 0 | Domestic and international OCR platforms and services |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 | --- | ---: | --- |
 | [论文](papers/README.md) | 244 | OCR、文档解析、版面分析和文档理解研究 |
 | [模型](models/README.md) | 110 | 具有模型卡、权重、API 或正式发布页的模型 |
-| [数据集](datasets/README.md) | 51 | 训练、预训练和评测数据集 |
+| [数据集](datasets/README.md) | 52 | 训练、预训练和评测数据集 |
 | [代码](codes/README.md) | 35 | 著名 OCR 与 Document AI 项目 |
 | [Skills](skills/README.md) | 104 | 可安装、可复用的 OCR/文档 Agent Skills |
 | [平台](platforms/README.md) | 0 | 国内外 OCR 平台、服务及介绍 |

--- a/data/codes/github--LaoFeng-mouse--flyingmouse-format.yaml
+++ b/data/codes/github--LaoFeng-mouse--flyingmouse-format.yaml
@@ -5,11 +5,29 @@ name: LaoFeng-mouse/flyingmouse-format
 released_at:
   value: '2026-08-06'
   precision: day
-  discovered_at: '2026-08-07'
+added_at: '2026-08-08'
+last_verified_at: '2026-08-08'
+summary: 飞鼠格式 FlyingMouse Format - Windows 万能文件格式转换工具（离线可用，内置 FFmpeg/LibreOffice/Poppler/Tesseract）。图片/文档/表格/PPT/PDF/音视频/WPS
+  格式互转 + OCR + 批量转换
+tasks:
+- text-recognition
+modalities:
+- unspecified
+languages:
+- unspecified
+links:
+  canonical: https://github.com/LaoFeng-mouse/flyingmouse-format
+license:
+  name: NOASSERTION
+relations: []
+provenance:
+  canonical_source: https://github.com/LaoFeng-mouse/flyingmouse-format
+  discovered_via: github
+  discovered_at: '2026-08-08'
   source_id: R_kgDOTvWWMQ
   source_metadata:
     repository: LaoFeng-mouse/flyingmouse-format
-    stars: 29
+    stars: 41
     language: JavaScript
     archived: false
     query: OCR in:name,description,readme

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -56,6 +56,7 @@ meta/info.json:
     },
     "data_path": "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet",
     "video_path":… See the full description on the dataset page: https://huggingface.co/datasets/alphabot2/07-08-2026_OCR_Bimanual. |
+| [boffire/adlis-pdfs-ocr-kab](https://huggingface.co/datasets/boffire/adlis-pdfs-ocr-kab) | 2026-08-06 | text-recognition | candidate | — |
 | [PersianML/persian-ocr-benchmark](https://huggingface.co/datasets/PersianML/persian-ocr-benchmark) | 2026-08-05 | text-recognition | candidate | 
 	
 		


### PR DESCRIPTION
Merge commit 26305fe resolved an add/add conflict on data/codes/github--LaoFeng-mouse--flyingmouse-format.yaml by deleting the wrong block, leaving the tail of `provenance` nested under `released_at` and dropping `added_at`, `last_verified_at`, `links`, and `provenance`.

Every `ocr-resources discover` run since then has failed at `load_resources()`, so the daily workflow has been red since 2026-08-09.

Restore the file to the valid 2026-08-08 version and re-render, which also recovers the `boffire/adlis-pdfs-ocr-kab` row that the same merge dropped from datasets/README.md and the dataset counts in both READMEs.

## Summary

<!-- What resource or maintenance behavior changes? -->

## Source and identity

- Canonical first-party URL:
- Resource kind:
- Duplicate keys checked (DOI/arXiv/Hub/GitHub/canonical URL):
- License source or `NOASSERTION`:

## Validation

- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run mypy src`
- [ ] `uv run pytest`
- [ ] `uv run ocr-resources validate`
- [ ] `uv run ocr-resources schemas --check`
- [ ] `uv run ocr-resources render --check`
- [ ] I reviewed generated Markdown and did not edit it directly.
- [ ] I did not install or execute code from a discovered resource.
