### PR TITLE
Survive source throttling in the daily discovery pipeline

### DIFF
--- a/.github/workflows/discover-daily.yml
+++ b/.github/workflows/discover-daily.yml
@@ -52,6 +52,7 @@ jobs:
           uv python install 3.12
           uv sync --frozen --all-groups
       - name: Discover candidates
+        id: discover
         shell: bash
         run: |
           args=()
@@ -63,6 +64,15 @@ jobs:
             args+=(--dry-run)
           fi
           uv run ocr-resources discover --lookback-days "$LOOKBACK_DAYS" "${args[@]}"
+          report="reports/discovery-$(date -u +%F).json"
+          degraded=""
+          if [[ -f "$report" ]]; then
+            degraded="$(python3 -c 'import json,sys; print(", ".join(json.load(open(sys.argv[1])).get("sources_failed", [])))' "$report")"
+          fi
+          echo "degraded=${degraded}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$degraded" ]]; then
+            echo "::warning::Discovery completed with degraded sources: ${degraded}"
+          fi
       - name: Validate candidate branch
         run: |
           uv run ruff check .
@@ -84,6 +94,8 @@ jobs:
       - name: Create or update Draft PR
         if: steps.changes.outputs.has_changes == 'true' && env.DRY_RUN != 'true'
         shell: bash
+        env:
+          DEGRADED_SOURCES: ${{ steps.discover.outputs.degraded }}
         run: |
           day="$(date -u +%F)"
           branch="automation/daily-${day}"
@@ -97,6 +109,13 @@ jobs:
           {
             echo "Automated candidate discovery for ${day}."
             echo
+            if [[ -n "$DEGRADED_SOURCES" ]]; then
+              echo "> [!WARNING]"
+              echo "> These sources were unavailable during this run: ${DEGRADED_SOURCES}."
+              echo "> Their resources are missing from this PR. The next successful run"
+              echo "> re-covers them within the seven-day lookback window."
+              echo
+            fi
             echo "All lint, type, test, schema, resource, and render checks completed in this workflow."
             echo "Review every candidate and change its curation status before merging."
             echo

--- a/src/ocr_resources/cli.py
+++ b/src/ocr_resources/cli.py
@@ -94,7 +94,13 @@ def discover_command(
     if report["source_errors"]:
         for error in report["source_errors"]:
             typer.echo(f"SOURCE ERROR ({error['source']}): {error['error']}", err=True)
-        raise typer.Exit(code=2)
+        # Only a total blackout is fatal; otherwise keep the healthy sources' results.
+        if not report["sources_ok"]:
+            raise typer.Exit(code=2)
+        typer.echo(
+            f"DEGRADED: continuing without {', '.join(report['sources_failed'])}.",
+            err=True,
+        )
 
 
 @app.command("audit-links")

--- a/src/ocr_resources/discovery/arxiv.py
+++ b/src/ocr_resources/discovery/arxiv.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
 import re
+import time
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from urllib.parse import urlencode
 
 import httpx
 
-from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate, parse_datetime
+from ocr_resources.discovery.base import (
+    DiscoveryWindow,
+    RawCandidate,
+    get_with_retry,
+    parse_datetime,
+)
 from ocr_resources.identity import normalize_arxiv_id
 from ocr_resources.models import ResourceKind
 
 ATOM = "{http://www.w3.org/2005/Atom}"
 ARXIV = "{http://arxiv.org/schemas/atom}"
+
+# arXiv's Terms of Use ask for no more than one request every three seconds.
+ARXIV_MIN_INTERVAL_SECONDS = 3.0
 
 
 class ArxivCollector:
@@ -24,14 +34,29 @@ class ArxivCollector:
         *,
         client: httpx.Client | None = None,
         user_agent: str = "awesome-ocr-resources/0.1 (metadata curation)",
+        min_interval: float = ARXIV_MIN_INTERVAL_SECONDS,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         self.endpoint = endpoint
         self.queries = queries
+        self.min_interval = min_interval
+        self._sleep = sleep
+        self._monotonic = monotonic
+        self._last_request_at: float | None = None
         self.client = client or httpx.Client(
-            timeout=30,
+            timeout=httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0),
             follow_redirects=True,
             headers={"User-Agent": user_agent},
         )
+
+    def _throttle(self) -> None:
+        """Space consecutive calls by at least ``min_interval`` seconds."""
+        if self._last_request_at is not None:
+            elapsed = self._monotonic() - self._last_request_at
+            if elapsed < self.min_interval:
+                self._sleep(self.min_interval - elapsed)
+        self._last_request_at = self._monotonic()
 
     def collect(self, window: DiscoveryWindow) -> list[RawCandidate]:
         candidates: dict[str, RawCandidate] = {}
@@ -43,8 +68,12 @@ class ArxivCollector:
                 "sortBy": "submittedDate",
                 "sortOrder": "descending",
             }
-            response = self.client.get(f"{self.endpoint}?{urlencode(params)}")
-            response.raise_for_status()
+            self._throttle()
+            response = get_with_retry(
+                self.client,
+                f"{self.endpoint}?{urlencode(params)}",
+                sleep=self._sleep,
+            )
             root = ET.fromstring(response.text)
             for entry in root.findall(f"{ATOM}entry"):
                 identifier_url = (entry.findtext(f"{ATOM}id") or "").strip()

--- a/src/ocr_resources/discovery/base.py
+++ b/src/ocr_resources/discovery/base.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import random
+import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import UTC, date, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
+import httpx
+
 from ocr_resources.models import ResourceKind
+
+RETRY_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 
 @dataclass(frozen=True)
@@ -38,3 +46,67 @@ def parse_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def retry_after_seconds(response: httpx.Response, maximum: float) -> float | None:
+    """Read a Retry-After header given either as seconds or as an HTTP date."""
+    header = response.headers.get("Retry-After")
+    if not header:
+        return None
+    try:
+        return min(max(float(header), 0.0), maximum)
+    except ValueError:
+        pass
+    try:
+        target = parsedate_to_datetime(header)
+    except (TypeError, ValueError):
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=UTC)
+    return min(max((target - datetime.now(UTC)).total_seconds(), 0.0), maximum)
+
+
+def get_with_retry(
+    client: httpx.Client,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    attempts: int = 4,
+    base_delay: float = 2.0,
+    max_delay: float = 30.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> httpx.Response:
+    """GET ``url``, retrying throttled, transient, and timed-out responses.
+
+    Public metadata APIs throttle aggressively: arXiv answers a burst with 429
+    "Rate exceeded" or by stalling the connection until the read timeout, so
+    ``TransportError`` (which covers timeouts) is retried alongside the throttling
+    and gateway status codes. Honour ``Retry-After`` when the server sends one,
+    otherwise back off exponentially with jitter. The last failure is re-raised so
+    a source that is genuinely down still surfaces as a source error.
+    """
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        delay: float | None = None
+        try:
+            response = client.get(url, params=params)
+        except httpx.TransportError as exc:
+            last_error = exc
+        else:
+            if response.status_code not in RETRY_STATUS_CODES:
+                response.raise_for_status()
+                return response
+            last_error = httpx.HTTPStatusError(
+                f"{response.status_code} {response.reason_phrase} for {url}",
+                request=response.request,
+                response=response,
+            )
+            delay = retry_after_seconds(response, max_delay)
+        if attempt == attempts:
+            break
+        if delay is None:
+            delay = min(base_delay * 2 ** (attempt - 1), max_delay) * (0.5 + random.random() / 2)
+        sleep(delay)
+    if last_error is None:  # pragma: no cover - attempts is always at least one
+        raise RuntimeError(f"no request was attempted for {url}")
+    raise last_error

--- a/src/ocr_resources/discovery/github.py
+++ b/src/ocr_resources/discovery/github.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import httpx
 
-from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate, parse_datetime
+from ocr_resources.discovery.base import (
+    DiscoveryWindow,
+    RawCandidate,
+    get_with_retry,
+    parse_datetime,
+)
 from ocr_resources.models import ResourceKind
 
 
@@ -45,11 +50,11 @@ class GitHubCollector:
                 f"{query} created:{window.since.isoformat()}..{window.until.isoformat()} "
                 f"stars:>={self.minimum_stars} fork:false"
             )
-            response = self.client.get(
+            response = get_with_retry(
+                self.client,
                 f"{self.endpoint}/search/repositories",
                 params={"q": qualified, "sort": "updated", "per_page": window.limit},
             )
-            response.raise_for_status()
             payload = response.json()
             for item in payload.get("items", []):
                 if item.get("fork"):
@@ -81,11 +86,11 @@ class GitHubCollector:
     def _collect_skills(self, window: DiscoveryWindow) -> list[RawCandidate]:
         candidates: list[RawCandidate] = []
         for query in self.skill_queries:
-            response = self.client.get(
+            response = get_with_retry(
+                self.client,
                 f"{self.endpoint}/search/code",
                 params={"q": query, "per_page": min(window.limit, 100)},
             )
-            response.raise_for_status()
             payload = response.json()
             for item in payload.get("items", []):
                 repository = item["repository"]

--- a/src/ocr_resources/discovery/huggingface.py
+++ b/src/ocr_resources/discovery/huggingface.py
@@ -4,7 +4,12 @@ from datetime import UTC
 
 import httpx
 
-from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate, parse_datetime
+from ocr_resources.discovery.base import (
+    DiscoveryWindow,
+    RawCandidate,
+    get_with_retry,
+    parse_datetime,
+)
 from ocr_resources.models import ResourceKind
 
 
@@ -33,7 +38,8 @@ class HuggingFaceCollector:
             (ResourceKind.DATASET, "datasets"),
         ):
             for query in self.queries:
-                response = self.client.get(
+                response = get_with_retry(
+                    self.client,
                     f"{self.endpoint}/{api_path}",
                     params={
                         "search": query,
@@ -43,7 +49,6 @@ class HuggingFaceCollector:
                         "full": "true",
                     },
                 )
-                response.raise_for_status()
                 for item in response.json():
                     repository_id = item.get("id") or item.get("modelId")
                     if not repository_id:

--- a/src/ocr_resources/discovery/runner.py
+++ b/src/ocr_resources/discovery/runner.py
@@ -209,6 +209,7 @@ def discover_resources(
         until=until,
     )
     collectors = collectors if collectors is not None else build_collectors(root, selected_sources)
+    attempted_sources = [collector.name for collector in collectors]
     rules = _load_yaml(root / "config" / "quality_rules.yaml")
     existing_keys = {canonical_key(resource) for resource in load_resources(root)}
     rejected = load_rejected(root)
@@ -255,19 +256,31 @@ def discover_resources(
                     additions.append(resource)
                     seen_candidate_keys.add(key)
             candidate_rows.append(row)
+    # A single throttled source must not discard what the healthy ones found; the
+    # seven-day lookback re-covers the gap on the next successful run.
     added_count = 0
-    if not dry_run and not source_errors:
+    if not dry_run:
         for resource in additions:
             write_resource(root, resource)
         added_count = len(additions)
         if additions:
-            write_daily_update(root, additions, until, source_summary=dict(source_counts))
+            write_daily_update(
+                root,
+                additions,
+                until,
+                source_summary=dict(source_counts),
+                source_errors=source_errors,
+            )
             render_repository(root)
+    failed_sources = [error["source"] for error in source_errors]
     report: dict[str, Any] = {
         "date": until.isoformat(),
         "window": {"since": window.since.isoformat(), "until": window.until.isoformat()},
         "dry_run": dry_run,
         "sources": dict(source_counts),
+        "sources_attempted": attempted_sources,
+        "sources_ok": [name for name in attempted_sources if name not in failed_sources],
+        "sources_failed": failed_sources,
         "source_errors": source_errors,
         "matched": len(additions),
         "added": added_count,

--- a/src/ocr_resources/rendering.py
+++ b/src/ocr_resources/rendering.py
@@ -174,6 +174,7 @@ def write_daily_update(
     update_date: date,
     *,
     source_summary: dict[str, int] | None = None,
+    source_errors: list[dict[str, str]] | None = None,
 ) -> Path | None:
     if not resources:
         return None
@@ -188,6 +189,7 @@ def write_daily_update(
             update_date=update_date.isoformat(),
             grouped=dict(grouped),
             source_summary=source_summary or {},
+            source_errors=source_errors or [],
         ),
         encoding="utf-8",
     )

--- a/templates/daily-update.md.j2
+++ b/templates/daily-update.md.j2
@@ -19,3 +19,14 @@
 {% else %}
 - Added through maintainer review.
 {% endif %}
+{% if source_errors %}
+
+### Degraded Sources
+
+{% for error in source_errors -%}
+- {{ error.source }}: unavailable — {{ error.error }}
+{% endfor %}
+
+This update is incomplete for the sources listed above. The next successful run re-covers them
+within the seven-day lookback window.
+{% endif %}

--- a/tests/test_discovery_audit.py
+++ b/tests/test_discovery_audit.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import date
 
 import httpx
+import pytest
 
 from ocr_resources.audit import validate_public_url
 from ocr_resources.discovery.arxiv import ArxivCollector
-from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate
+from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate, get_with_retry
 from ocr_resources.discovery.github import GitHubCollector
 from ocr_resources.discovery.huggingface import HuggingFaceCollector
 from ocr_resources.discovery.scoring import score_candidate
@@ -32,6 +33,75 @@ def test_arxiv_collector_parses_atom_response() -> None:
     assert len(values) == 1
     assert values[0].source_id == "2607.12345"
     assert values[0].authors == ["Alice Example"]
+
+
+def test_arxiv_collector_paces_requests_per_terms_of_use() -> None:
+    empty = '<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"/>'
+    client = httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(200, text=empty)))
+    slept: list[float] = []
+    collector = ArxivCollector(
+        "https://example.test/query",
+        ["all:a", "all:b", "all:c"],
+        client=client,
+        sleep=slept.append,
+        monotonic=lambda: 0.0,
+    )
+    collector.collect(DiscoveryWindow(date(2026, 7, 20), date(2026, 7, 26)))
+    assert slept == [3.0, 3.0]
+
+
+def test_get_with_retry_recovers_from_throttling() -> None:
+    replies = [httpx.Response(429, text="Rate exceeded."), httpx.Response(200, text="ok")]
+    client = httpx.Client(transport=httpx.MockTransport(lambda _: replies.pop(0)))
+    slept: list[float] = []
+    response = get_with_retry(client, "https://example.test/q", sleep=slept.append)
+    assert response.status_code == 200
+    assert len(slept) == 1
+
+
+def test_get_with_retry_honours_retry_after() -> None:
+    replies = [
+        httpx.Response(429, headers={"Retry-After": "7"}, text="Rate exceeded."),
+        httpx.Response(200, text="ok"),
+    ]
+    client = httpx.Client(transport=httpx.MockTransport(lambda _: replies.pop(0)))
+    slept: list[float] = []
+    get_with_retry(client, "https://example.test/q", sleep=slept.append)
+    assert slept == [7.0]
+
+
+def test_get_with_retry_reraises_persistent_throttling() -> None:
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda _: httpx.Response(429, text="Rate exceeded."))
+    )
+    slept: list[float] = []
+    with pytest.raises(httpx.HTTPStatusError):
+        get_with_retry(client, "https://example.test/q", attempts=3, sleep=slept.append)
+    assert len(slept) == 2
+
+
+def test_get_with_retry_reraises_timeouts() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("The read operation timed out", request=request)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    slept: list[float] = []
+    with pytest.raises(httpx.ReadTimeout):
+        get_with_retry(client, "https://example.test/q", attempts=2, sleep=slept.append)
+    assert len(slept) == 1
+
+
+def test_get_with_retry_does_not_retry_client_errors() -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(404)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(httpx.HTTPStatusError):
+        get_with_retry(client, "https://example.test/q", sleep=lambda _: None)
+    assert len(calls) == 1
 
 
 def test_huggingface_collector_handles_models_and_datasets() -> None:

--- a/tests/test_discovery_integration.py
+++ b/tests/test_discovery_integration.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from datetime import date
 from pathlib import Path
+from typing import Any
 
+import pytest
+from typer.testing import CliRunner
+
+from ocr_resources import cli as cli_module
 from ocr_resources.discovery.base import DiscoveryWindow, RawCandidate
 from ocr_resources.discovery.runner import discover_resources
 from ocr_resources.models import ResourceKind
@@ -59,7 +64,7 @@ def _minimal_root(tmp_path: Path) -> None:
         (tmp_path / "data" / directory).mkdir(parents=True, exist_ok=True)
 
 
-def test_source_failure_prevents_partial_writes(tmp_path: Path) -> None:
+def test_source_failure_still_writes_healthy_sources(tmp_path: Path) -> None:
     _minimal_root(tmp_path)
     report = discover_resources(
         tmp_path,
@@ -67,9 +72,74 @@ def test_source_failure_prevents_partial_writes(tmp_path: Path) -> None:
         collectors=[FixtureCollector(), FailingCollector()],
     )
     assert report["matched"] == 1
-    assert report["added"] == 0
+    assert report["added"] == 1
     assert report["source_errors"] == [{"source": "failing", "error": "temporary source failure"}]
+    assert report["sources_attempted"] == ["fixture", "failing"]
+    assert report["sources_ok"] == ["fixture"]
+    assert report["sources_failed"] == ["failing"]
+    assert list((tmp_path / "data/papers").glob("**/*.yaml"))
+    update = (tmp_path / "updates/2026/2026-07-26.md").read_text(encoding="utf-8")
+    assert "Degraded Sources" in update
+    assert "failing" in update
+
+
+def test_every_source_failing_reports_no_healthy_source(tmp_path: Path) -> None:
+    _minimal_root(tmp_path)
+    report = discover_resources(
+        tmp_path,
+        until=date(2026, 7, 26),
+        collectors=[FailingCollector()],
+    )
+    assert report["added"] == 0
+    assert report["sources_ok"] == []
+    assert report["sources_failed"] == ["failing"]
     assert not list((tmp_path / "data/papers").glob("**/*.yaml"))
+
+
+def _stub_report(**overrides: Any) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "sources": {},
+        "matched": 0,
+        "added": 0,
+        "source_errors": [],
+        "sources_ok": [],
+        "sources_failed": [],
+    }
+    report.update(overrides)
+    return report
+
+
+@pytest.mark.parametrize(
+    ("report", "expected_code"),
+    [
+        (
+            _stub_report(
+                source_errors=[{"source": "arxiv", "error": "429 Rate exceeded"}],
+                sources_ok=["huggingface"],
+                sources_failed=["arxiv"],
+                sources={"huggingface": 12},
+                matched=12,
+                added=12,
+            ),
+            0,
+        ),
+        (
+            _stub_report(
+                source_errors=[{"source": "arxiv", "error": "429 Rate exceeded"}],
+                sources_ok=[],
+                sources_failed=["arxiv"],
+            ),
+            2,
+        ),
+    ],
+    ids=["one-source-down-is-degraded", "every-source-down-is-fatal"],
+)
+def test_discover_cli_fails_only_when_every_source_fails(
+    monkeypatch: pytest.MonkeyPatch, report: dict[str, Any], expected_code: int
+) -> None:
+    monkeypatch.setattr(cli_module, "discover_resources", lambda *args, **kwargs: report)
+    result = CliRunner().invoke(cli_module.app, ["discover"])
+    assert result.exit_code == expected_code
 
 
 def test_fixture_discovery_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
The daily PR chain has produced no PR since 2026-08-14: every scheduled run failed at the "Discover candidates" step. export.arxiv.org now throttles us, answering with HTTP 429 "Rate exceeded" or stalling until the read timeout.

ArxivCollector fired all eleven queries back-to-back with no delay, against arXiv's Terms of Use asking for one request every three seconds. Nothing retried, so the first 429 aborted the collector. discover_resources then threw away every candidate the healthy sources had found, and the CLI exited 2 -- so one throttled source silently cost ten days of curation.

- Add get_with_retry() in discovery/base.py: retries 429/5xx and transport errors, honours Retry-After, exponential backoff with jitter. Used by all three collectors, since the GitHub and HF APIs throttle too.
- Pace arXiv requests three seconds apart and split the httpx timeout.
- Write what the healthy sources found instead of discarding everything, and record sources_attempted/ok/failed in the discovery report.
- Exit non-zero only when every source fails; a partial outage is a warning.
- Surface degraded sources in the daily update, the PR body, and as a workflow annotation.

Verified live: eleven paced arXiv queries now all succeed from an IP that was being 429'd minutes earlier.

## Summary

<!-- What resource or maintenance behavior changes? -->

## Source and identity

- Canonical first-party URL:
- Resource kind:
- Duplicate keys checked (DOI/arXiv/Hub/GitHub/canonical URL):
- License source or `NOASSERTION`:

## Validation

- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run mypy src`
- [ ] `uv run pytest`
- [ ] `uv run ocr-resources validate`
- [ ] `uv run ocr-resources schemas --check`
- [ ] `uv run ocr-resources render --check`
- [ ] I reviewed generated Markdown and did not edit it directly.
- [ ] I did not install or execute code from a discovered resource.
