### PR TITLE
Add dataset: Velrim absent-field extraction bake-off (velrim-eval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A structured and human-curated collection of OCR and Document AI resources. Auto
 | --- | ---: | --- |
 | [Papers](papers/README.md) | 276 | Research on OCR, document parsing, layout analysis, and document understanding |
 | [Models](models/README.md) | 339 | Public model cards, weights, APIs, and official model releases |
-| [Datasets](datasets/README.md) | 189 | Training datasets and evaluation benchmarks |
+| [Datasets](datasets/README.md) | 190 | Training datasets and evaluation benchmarks |
 | [Codes](codes/README.md) | 84 | Notable OCR and Document AI codebases |
 | [Skills](skills/README.md) | 245 | Installable agent skills for OCR and document workflows |
 | [Platforms](platforms/README.md) | 0 | Domestic and international OCR platforms and services |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 | --- | ---: | --- |
 | [论文](papers/README.md) | 276 | OCR、文档解析、版面分析和文档理解研究 |
 | [模型](models/README.md) | 339 | 具有模型卡、权重、API 或正式发布页的模型 |
-| [数据集](datasets/README.md) | 189 | 训练、预训练和评测数据集 |
+| [数据集](datasets/README.md) | 190 | 训练、预训练和评测数据集 |
 | [代码](codes/README.md) | 84 | 著名 OCR 与 Document AI 项目 |
 | [Skills](skills/README.md) | 245 | 可安装、可复用的 OCR/文档 Agent Skills |
 | [平台](platforms/README.md) | 0 | 国内外 OCR 平台、服务及介绍 |

--- a/data/datasets/github--velrimhq--velrim-eval.yaml
+++ b/data/datasets/github--velrimhq--velrim-eval.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+id: dataset:github:velrimhq/velrim-eval
+kind: dataset
+name: Velrim absent-field extraction bake-off (velrim-eval)
+released_at:
+  value: '2026-09-02'
+  precision: day
+added_at: '2026-09-02'
+last_verified_at: '2026-09-02'
+summary: Pre-registered six-arm benchmark of fabrication on absent fields in schema-guided
+  document extraction, with the eval CLI that scores it. 124 real documents and 2,102 labeled
+  fields from CORD-v2 receipts, DeepForm FCC invoices and VRDU ad-buy contracts and registration
+  forms, hand-audited absent-field labels plus planted probe fields, and every raw per-field output
+  with request IDs from six systems (Gemini 2.5 Flash x2, GPT-5.4-mini x2, Mistral Document AI OCR,
+  Velrim). Analysis plan committed publicly before the first paid call; re-scoring the published
+  outputs needs no API keys. Disclosure - Velrim ran the comparison and is one of the six systems.
+tasks:
+- key-information-extraction
+modalities:
+- unspecified
+languages:
+- unspecified
+links:
+  canonical: https://github.com/velrimhq/velrim-eval
+  homepage: https://velrim.com/research/fabrication-on-absent-fields
+  paper: https://doi.org/10.5281/zenodo.22233430
+  code: https://github.com/velrimhq/velrim-eval
+  dataset: https://github.com/velrimhq/velrim-eval
+license:
+  name: Apache-2.0 (code and results); CC-BY-4.0 / MIT (source corpora, see ATTRIBUTIONS.md)
+  url: https://github.com/velrimhq/velrim-eval/blob/main/ATTRIBUTIONS.md
+relations: []
+provenance:
+  canonical_source: https://github.com/velrimhq/velrim-eval
+  discovered_via: manual
+  discovered_at: '2026-09-02'
+  source_id: velrimhq/velrim-eval
+  source_metadata:
+    repository: velrimhq/velrim-eval
+    doi: 10.5281/zenodo.22233430
+    submitted_by: resource owner (Velrim)
+  legacy_duplicates: []
+curation:
+  status: candidate
+provider: Velrim
+repository_id: velrimhq/velrim-eval
+usage:
+- benchmark
+sample_count: 124
+annotations:
+- per-field golden labels
+- hand-audited absent-field labels
+- planted probe fields
+access: open

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -4,6 +4,7 @@
 
 | Resource | Released | Tasks | Status | Description |
 | --- | --- | --- | --- | --- |
+| [Velrim absent-field extraction bake-off (velrim-eval)](https://github.com/velrimhq/velrim-eval) | 2026-09-02 | key-information-extraction | candidate | Pre-registered six-arm benchmark of fabrication on absent fields in schema-guided document extraction, with the eval CLI that scores it. 124 real documents and 2,102 labeled fields from CORD-v2 receipts, DeepForm FCC invoices and VRDU ad-buy contracts and registration forms, hand-audited absent-field labels plus planted probe fields, and every raw per-field output with request IDs from six systems (Gemini 2.5 Flash x2, GPT-5.4-mini x2, Mistral Document AI OCR, Velrim). Analysis plan committed publicly before the first paid call; re-scoring the published outputs needs no API keys. Disclosure - Velrim ran the comparison and is one of the six systems. |
 | [wuvictor/work-document-ocr](https://huggingface.co/datasets/wuvictor/work-document-ocr) | 2026-09-01 | text-recognition | candidate | 
 	
 		


### PR DESCRIPTION
## Summary

Adds one dataset resource: the Velrim absent-field extraction bake-off, a pre-registered six-arm benchmark of fabrication on absent fields in schema-guided document extraction (124 real documents, 2,102 labeled fields from CORD-v2, DeepForm and VRDU; six systems: Gemini 2.5 Flash x2, GPT-5.4-mini x2, Mistral Document AI OCR, Velrim), together with the `velrim-eval` scoring CLI and every raw per-field output. Generated Markdown re-rendered with `ocr-resources render`, not edited by hand.

Disclosure: submitted by the resource owner. Velrim ran the comparison and is one of the six systems scored. The analysis plan was committed publicly before the first paid call; re-scoring the published outputs needs no API keys.

## Source and identity

- Canonical first-party URL: https://github.com/velrimhq/velrim-eval (write-up: https://velrim.com/research/fabrication-on-absent-fields, archive DOI: https://doi.org/10.5281/zenodo.22233430)
- Resource kind: dataset
- Duplicate keys checked (DOI/arXiv/Hub/GitHub/canonical URL): searched `data/` for velrimhq/velrim-eval, velrim.com and the DOI, no matches
- License source or `NOASSERTION`: Apache-2.0 for code and results (LICENSE in the repo); source corpora CC BY 4.0 / MIT per ATTRIBUTIONS.md, both recorded in the entry

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`
- [x] `uv run pytest` (24 passed; `test_render_is_idempotent_and_keeps_legacy_paths` fails on this Windows checkout with or without the new entry, the renderer writes CRLF there, so it looks environment-specific rather than related to this change)
- [x] `uv run ocr-resources validate`
- [x] `uv run ocr-resources schemas --check`
- [x] `uv run ocr-resources render --check`
- [x] I reviewed generated Markdown and did not edit it directly.
- [x] I did not install or execute code from a discovered resource.